### PR TITLE
Add npm init step to npm installation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,6 +120,9 @@ First you must install and configure {uri-nodejs-download}[Node.js] on your mach
 
 Using npm:
 
+Create a directory to place slides. Initialize the directory to store npm packages within that directory. 
+
+ $ npm init
  $ npm i --save asciidoctor.js@1.5.5-3
  $ npm i --save asciidoctor-reveal.js
 


### PR DESCRIPTION
Add instructions to the npm installation section. Create a new folder for slides and then do npm init in that folder. If slides are stored away from the directory where 'node_modules' exists, then there will be an error when attempting to generate slides for a file not found issue.